### PR TITLE
Specify .bandit file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
 
       - run:
           name: Bandit
-          command: pipenv run bandit -r .
+          command: pipenv run bandit -r . --ini .bandit
 
       # - run:
       #     name: Codecov


### PR DESCRIPTION
Since django-data-ingest also has a .bandit file, a file is needed to be specified to choose the correct file to use.