### PR TITLE
Include precision numbers for division error messages

### DIFF
--- a/usda_fns_ingestor/usda_sql_rules.yml
+++ b/usda_fns_ingestor/usda_sql_rules.yml
@@ -409,7 +409,7 @@
             )
         )
   columns: [S32B_dc_snap_stud, S33B_dc_other_stud, S34B_free_snap_letter_stud, S41A_free_doc_apps, S41B_free_doc_stud]
-  message: 'You are reporting on average {S41B_free_doc_stud/S41A_free_doc_apps} students per application for the categorically
+  message: 'You are reporting on average {S41B_free_doc_stud/S41A_free_doc_apps:1} students per application for the categorically
     eligible FREE applications. Even with the different reference dates for these
     two fields (Oct 1 vs Oct 31), this is unexpectedly high. Please confirm that the
     numbers of students and applications reported in fields 4-1:A and 4-1:B are correct.
@@ -460,7 +460,7 @@
           )
         )
   columns: [S32B_dc_snap_stud, S33B_dc_other_stud, S34B_free_snap_letter_stud, S41A_free_doc_apps, S41B_free_doc_stud]
-  message: 'You are reporting on average {S41B_free_doc_stud/S41A_free_doc_apps} students per application for the categorically
+  message: 'You are reporting on average {S41B_free_doc_stud/S41A_free_doc_apps:1} students per application for the categorically
     eligible FREE applications. Even with the different reference dates for these
     two fields (Oct 1 vs Oct 31), this is unexpectedly high. Please correct the number
     of students and applications reported in fields 4-1:A and/or 4-1:B. Note: Do not
@@ -671,7 +671,7 @@
   check_origin: NEW check
   code: S42A_free_inc_apps > 10 and (S42B_free_inc_stud/S42A_free_inc_apps) >= 5
   columns: [S42A_free_inc_apps, S42B_free_inc_stud]
-  message: 'You are reporting on average {S42B_free_inc_stud/S42A_free_inc_apps} students per application for the FREE
+  message: 'You are reporting on average {S42B_free_inc_stud/S42A_free_inc_apps:1} students per application for the FREE
     income applications. Even with the difference in reference dates for these two
     fields (Oct 1 vs Oct 31), this is unexpectedly high. Please correct the number
     of students and applications reported in fields 4-2:A and/or 4-2:B.'
@@ -681,7 +681,7 @@
   code: S42A_free_inc_apps > 10 and (CAST(S42B_free_inc_stud AS FLOAT)/S42A_free_inc_apps) > 3 and
     (CAST(S42B_free_inc_stud AS FLOAT)/S42A_free_inc_apps) < 5
   columns: [S42A_free_inc_apps, S42B_free_inc_stud]
-  message: 'You are reporting on average {S42B_free_inc_stud/S42A_free_inc_apps} students per application for the FREE
+  message: 'You are reporting on average {S42B_free_inc_stud/S42A_free_inc_apps:1} students per application for the FREE
     income applications. Even with the difference in reference dates for these two
     fields (Oct 1 vs Oct 31), this is unexpectedly high. Please confirm that the numbers
     of students and applications reported in fields 4-2:A and 4-2:B are correct.'
@@ -690,7 +690,7 @@
   check_origin: NEW check
   code: S42A_free_inc_apps > 1 and S42A_free_inc_apps <= 10 and (CAST(S42B_free_inc_stud AS FLOAT)/S42A_free_inc_apps) >= 10
   columns: [S42A_free_inc_apps, S42B_free_inc_stud]
-  message: 'You are reporting on average {S42B_free_inc_stud/S42A_free_inc_apps} students per application for the FREE
+  message: 'You are reporting on average {S42B_free_inc_stud/S42A_free_inc_apps:1} students per application for the FREE
     income applications. Even with the difference in reference dates for these two
     fields (Oct 1 vs Oct 31), this is unexpectedly high. Please correct the number
     of students and applications reported in fields 4-2:A and/or 4-2:B.'
@@ -701,7 +701,7 @@
     and (CAST(S42B_free_inc_stud as FLOAT)/S42A_free_inc_apps) > 5
     and (CAST(S42B_free_inc_stud as FLOAT)/S42A_free_inc_apps) < 10
   columns: [S42A_free_inc_apps, S42B_free_inc_stud]
-  message: 'You are reporting on average {S42B_free_inc_stud/S42A_free_inc_apps} students per application for the FREE
+  message: 'You are reporting on average {S42B_free_inc_stud/S42A_free_inc_apps:1} students per application for the FREE
     income applications. Even with the difference in reference dates for these two
     fields (Oct 1 vs Oct 31), this is unexpectedly high. Please confirm that the numbers
     of students and applications reported in fields 4-2:A and 4-2:B are correct.'
@@ -710,7 +710,7 @@
   check_origin: NEW check
   code: S43A_rp_inc_apps > 10 and (CAST(S43B_rp_inc_stud AS FLOAT)/S43A_rp_inc_apps) >= 5
   columns: [S43A_rp_inc_apps, S43B_rp_inc_stud]
-  message: 'You are reporting on average {S43B_rp_inc_stud/S43A_rp_inc_apps} students per application for the reduced
+  message: 'You are reporting on average {S43B_rp_inc_stud/S43A_rp_inc_apps:1} students per application for the reduced
     price applications. Even with the difference in reference dates for these two
     fields (Oct 1 vs Oct 31), this is unexpectedly high. Please correct the number
     of students and applications reported in fields 4-3:A and/or 4-3:B.'
@@ -721,7 +721,7 @@
     (CAST(S43B_rp_inc_stud AS FLOAT)/S43A_rp_inc_apps) > 3 and
     (CAST(S43B_rp_inc_stud AS FLOAT)/S43A_rp_inc_apps) < 5
   columns: [S43A_rp_inc_apps, S43B_rp_inc_stud]
-  message: 'You are reporting on average {S43B_rp_inc_stud/S43A_rp_inc_apps} students per application for the reduced
+  message: 'You are reporting on average {S43B_rp_inc_stud/S43A_rp_inc_apps:1} students per application for the reduced
     price applications. Even with the difference in reference dates for these two
     fields (Oct 1 vs Oct 31), this is unexpectedly high. Please confirm that the numbers
     of students and applications reported in fields 4-3:A and 4-3:B are correct.'
@@ -730,7 +730,7 @@
   check_origin: NEW check
   code: S43A_rp_inc_apps > 1 and S43A_rp_inc_apps <= 10 and (CAST(S43B_rp_inc_stud AS FLOAT)/S43A_rp_inc_apps) >= 10
   columns: [S43A_rp_inc_apps, S43B_rp_inc_stud]
-  message: 'You are reporting on average {S43B_rp_inc_stud/S43A_rp_inc_apps} students per application for the reduced
+  message: 'You are reporting on average {S43B_rp_inc_stud/S43A_rp_inc_apps:1} students per application for the reduced
     price applications. Even with the difference in reference dates for these two
     fields (Oct 1 vs Oct 31), this is unexpectedly high. Please correct the number
     of students and applications reported in fields 4-3:A and/or 4-3:B.'
@@ -741,7 +741,7 @@
     (CAST(S43B_rp_inc_stud as FLOAT)/S43A_rp_inc_apps) > 5 and
     (CAST(S43B_rp_inc_stud as FLOAT)/S43A_rp_inc_apps) < 10
   columns: [S43A_rp_inc_apps, S43B_rp_inc_stud]
-  message: 'You are reporting on average {S43B_rp_inc_stud/S43A_rp_inc_apps} students per application for the reduced
+  message: 'You are reporting on average {S43B_rp_inc_stud/S43A_rp_inc_apps:1} students per application for the reduced
     price applications. Even with the difference in reference dates for these two
     fields (Oct 1 vs Oct 31), this is unexpectedly high. Please confirm that the numbers
     of students and applications reported in fields 4-3:A and 4-3:B are correct.'


### PR DESCRIPTION
This will work after this PR is merged: https://github.com/18F/django-data-ingest/pull/24

## Addition:
- Specified to use one decimal place for all divisions

## Test:
- Manually tested with real data that triggered these errors