### PR TITLE
Add correct stack

### DIFF
--- a/usda_fns_ingestor/manifest.yml
+++ b/usda_fns_ingestor/manifest.yml
@@ -1,5 +1,5 @@
 applications:
-- name: usda-fns-ingestor-test
+- name: usda-fns-ingestor
   stack: cflinuxfs3
   services:
    - usda-fns-ingestor-db

--- a/usda_fns_ingestor/manifest.yml
+++ b/usda_fns_ingestor/manifest.yml
@@ -1,4 +1,5 @@
 applications:
-- name: usda-fns-ingestor
+- name: usda-fns-ingestor-test
+  stack: cflinuxfs3
   services:
    - usda-fns-ingestor-db


### PR DESCRIPTION
Currently we have not specified the exact stack to use, so it was using the `cflinuxfs2` stack.  This stack will not be supported according to update [here](https://cloud.gov/updates/2019-02-26-quarterly-update/).  `cflinuxfs3` should be used now.

## Additions:
- `cflinuxfs3` stack is added to `manifest.yml`

## Tests:
- Pushed to cloud.gov and did some manual testing to make sure everything still works.