### PR TITLE
Add private SFA type back to table schema

### DIFF
--- a/usda_fns_ingestor/usda_fns.json
+++ b/usda_fns_ingestor/usda_fns.json
@@ -7,6 +7,12 @@
       "description": "State ID"
     },
     {
+      "name": "type_sfa_private",
+      "title": "Type of SFA: Private/Nonprofit",
+      "type": "integer",
+      "description": "Type of SFA: Private/Nonprofit"
+    },
+    {
       "name": "school_year_from",
       "title": "School Year From",
       "type": "integer",


### PR DESCRIPTION
This is to fix issue #23.

## Additions
- Added `type_sfa_private` to table schema to enable type checking

## Tests:
- Manual testing were done with some data to check that there's no `extra-header` `whole_table_errors`
- Right now `whole_table_errors` are not tested, this will be fixed in issue #26 .