### PR TITLE
Pin down to ReVAL v0.4.0

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-django-data-ingest = {editable = true,git = "https://github.com/18F/django-data-ingest.git",ref = "master"}
+data-ingest = {editable = true,git = "https://github.com/18F/ReVAL.git",ref = "v0.4.0"}
 
 [dev-packages]
 flake8 = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "726ca5945a24ea11bec16e61d6101c051373200a04f961f8e30beb9a23ddd0c1"
+            "sha256": "5112a287d521e120935b8d7ba7cafc90985501843efc52a2498d7b2b30b536df"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -72,9 +72,14 @@
         },
         "click-default-group": {
             "hashes": [
-                "sha256:ba8c43d9c384e1ea7127484c5fc8f4e1ca759519a64fff10718d53f4b82c412a"
+                "sha256:31f6f22fcb3d558172badd51fde3c444af9c9d5af8480c5540b51db6805ffa29"
             ],
-            "version": "==1.2"
+            "version": "==1.2.1"
+        },
+        "data-ingest": {
+            "editable": true,
+            "git": "https://github.com/18F/ReVAL.git",
+            "ref": "fa1d3d317e57799cef84a6c546a3a1f8f44e9c7e"
         },
         "datapackage": {
             "hashes": [
@@ -96,11 +101,6 @@
                 "sha256:ba723e524facffa2a9d8c2e9116db871e16b9207e648e1d3e4af8aae1167b029"
             ],
             "version": "==1.11.21"
-        },
-        "django-data-ingest": {
-            "editable": true,
-            "git": "https://github.com/18F/django-data-ingest.git",
-            "ref": "3086d3f514799fe30a1d507b7a6be90009c59411"
         },
         "djangorestframework": {
             "hashes": [
@@ -209,36 +209,36 @@
         },
         "psycopg2-binary": {
             "hashes": [
-                "sha256:007ca0df127b1862fc010125bc4100b7a630efc6841047bd11afceadb4754611",
-                "sha256:03c49e02adf0b4d68f422fdbd98f7a7c547beb27e99a75ed02298f85cb48406a",
-                "sha256:0a1232cdd314e08848825edda06600455ad2a7adaa463ebfb12ece2d09f3370e",
-                "sha256:131c80d0958c89273d9720b9adf9df1d7600bb3120e16019a7389ab15b079af5",
-                "sha256:2de34cc3b775724623f86617d2601308083176a495f5b2efc2bbb0da154f483a",
-                "sha256:2eddc31500f73544a2a54123d4c4b249c3c711d31e64deddb0890982ea37397a",
-                "sha256:484f6c62bdc166ee0e5be3aa831120423bf399786d1f3b0304526c86180fbc0b",
-                "sha256:4c2d9369ed40b4a44a8ccd6bc3a7db6272b8314812d2d1091f95c4c836d92e06",
-                "sha256:70f570b5fa44413b9f30dbc053d17ef3ce6a4100147a10822f8662e58d473656",
-                "sha256:7a2b5b095f3bd733aab101c89c0e1a3f0dfb4ebdc26f6374805c086ffe29d5b2",
-                "sha256:804914a669186e2843c1f7fbe12b55aad1b36d40a28274abe6027deffad9433d",
-                "sha256:8520c03172da18345d012949a53617a963e0191ccb3c666f23276d5326af27b5",
-                "sha256:90da901fc33ea393fc644607e4a3916b509387e9339ec6ebc7bfded45b7a0ae9",
-                "sha256:a582416ad123291a82c300d1d872bdc4136d69ad0b41d57dc5ca3df7ef8e3088",
-                "sha256:ac8c5e20309f4989c296d62cac20ee456b69c41fd1bc03829e27de23b6fa9dd0",
-                "sha256:b2cf82f55a619879f8557fdaae5cec7a294fac815e0087c4f67026fdf5259844",
-                "sha256:b59d6f8cfca2983d8fdbe457bf95d2192f7b7efdb2b483bf5fa4e8981b04e8b2",
-                "sha256:be08168197021d669b9964bd87628fa88f910b1be31e7010901070f2540c05fd",
-                "sha256:be0f952f1c365061041bad16e27e224e29615d4eb1fb5b7e7760a1d3d12b90b6",
-                "sha256:c1c9a33e46d7c12b9c96cf2d4349d783e3127163fd96254dcd44663cf0a1d438",
-                "sha256:d18c89957ac57dd2a2724ecfe9a759912d776f96ecabba23acb9ecbf5c731035",
-                "sha256:d7e7b0ff21f39433c50397e60bf0995d078802c591ca3b8d99857ea18a7496ee",
-                "sha256:da0929b2bf0d1f365345e5eb940d8713c1d516312e010135b14402e2a3d2404d",
-                "sha256:de24a4962e361c512d3e528ded6c7480eab24c655b8ca1f0b761d3b3650d2f07",
-                "sha256:e45f93ff3f7dae2202248cf413a87aeb330821bf76998b3cf374eda2fc893dd7",
-                "sha256:f046aeae1f7a845041b8661bb7a52449202b6c5d3fb59eb4724e7ca088811904",
-                "sha256:f1dc2b7b2748084b890f5d05b65a47cd03188824890e9a60818721fd492249fb",
-                "sha256:fcbe7cf3a786572b73d2cd5f34ed452a5f5fac47c9c9d1e0642c457a148f9f88"
+                "sha256:080c72714784989474f97be9ab0ddf7b2ad2984527e77f2909fcd04d4df53809",
+                "sha256:110457be80b63ff4915febb06faa7be002b93a76e5ba19bf3f27636a2ef58598",
+                "sha256:171352a03b22fc099f15103959b52ee77d9a27e028895d7e5fde127aa8e3bac5",
+                "sha256:19d013e7b0817087517a4b3cab39c084d78898369e5c46258aab7be4f233d6a1",
+                "sha256:249b6b21ae4eb0f7b8423b330aa80fab5f821b9ffc3f7561a5e2fd6bb142cf5d",
+                "sha256:2ac0731d2d84b05c7bb39e85b7e123c3a0acd4cda631d8d542802c88deb9e87e",
+                "sha256:2b6d561193f0dc3f50acfb22dd52ea8c8dfbc64bcafe3938b5f209cc17cb6f00",
+                "sha256:2bd23e242e954214944481124755cbefe7c2cf563b1a54cd8d196d502f2578bf",
+                "sha256:3e1239242ca60b3725e65ab2f13765fc199b03af9eaf1b5572f0e97bdcee5b43",
+                "sha256:3eb70bb697abbe86b1d2b1316370c02ba320bfd1e9e35cf3b9566a855ea8e4e5",
+                "sha256:51a2fc7e94b98bd1bb5d4570936f24fc2b0541b63eccadf8fdea266db8ad2f70",
+                "sha256:52f1bdafdc764b7447e393ed39bb263eccb12bfda25a4ac06d82e3a9056251f6",
+                "sha256:5b3581319a3951f1e866f4f6c5e42023db0fae0284273b82e97dfd32c51985cd",
+                "sha256:63c1b66e3b2a3a336288e4bcec499e0dc310cd1dceaed1c46fa7419764c68877",
+                "sha256:8123a99f24ecee469e5c1339427bcdb2a33920a18bb5c0d58b7c13f3b0298ba3",
+                "sha256:85e699fcabe7f817c0f0a412d4e7c6627e00c412b418da7666ff353f38e30f67",
+                "sha256:8dbff4557bbef963697583366400822387cccf794ccb001f1f2307ed21854c68",
+                "sha256:908d21d08d6b81f1b7e056bbf40b2f77f8c499ab29e64ec5113052819ef1c89b",
+                "sha256:af39d0237b17d0a5a5f638e9dffb34013ce2b1d41441fd30283e42b22d16858a",
+                "sha256:af51bb9f055a3f4af0187149a8f60c9d516cf7d5565b3dac53358796a8fb2a5b",
+                "sha256:b2ecac57eb49e461e86c092761e6b8e1fd9654dbaaddf71a076dcc869f7014e2",
+                "sha256:cd37cc170678a4609becb26b53a2bc1edea65177be70c48dd7b39a1149cabd6e",
+                "sha256:d17e3054b17e1a6cb8c1140f76310f6ede811e75b7a9d461922d2c72973f583e",
+                "sha256:d305313c5a9695f40c46294d4315ed3a07c7d2b55e48a9010dad7db7a66c8b7f",
+                "sha256:dd0ef0eb1f7dd18a3f4187226e226a7284bda6af5671937a221766e6ef1ee88f",
+                "sha256:e1adff53b56db9905db48a972fb89370ad5736e0450b96f91bcf99cadd96cfd7",
+                "sha256:f0d43828003c82dbc9269de87aa449e9896077a71954fbbb10a614c017e65737",
+                "sha256:f78e8b487de4d92640105c1389e5b90be3496b1d75c90a666edd8737cc2dbab7"
             ],
-            "version": "==2.8.2"
+            "version": "==2.8.3"
         },
         "pyrsistent": {
             "hashes": [
@@ -471,10 +471,10 @@
         },
         "pbr": {
             "hashes": [
-                "sha256:0ce920b865091450bbcd452b35cf6d6eb8a6d9ce13ad2210d6e77557f85cf32b",
-                "sha256:93d2dc6ee0c9af4dbc70bc1251d0e545a9910ca8863774761f92716dece400b6"
+                "sha256:089ccb087e9bd8f278caedfa6c2c5d461381437eda3db750b6834e78b319f404",
+                "sha256:9fb1c3371344cd617eb073c6c00872e9b0e5a7fefed6cd29f327a1b26ab5c498"
             ],
-            "version": "==5.2.1"
+            "version": "==5.3.0"
         },
         "pycodestyle": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # usda-fns-ingestor
 
 An experiment in ingesting data for the USDA's Food and Nutrition Service
-using [django-data-ingest](https://github.com/18F/django-data-ingest).
+using [ReVAL](https://github.com/18F/ReVAL).
 
 Use [the webform](https://usda-fns-ingestor.app.cloud.gov/data_ingest/api/validate/) 
 to interactively upload files and see
@@ -19,9 +19,9 @@ Install development dependencies using [Pipenv](http://docs.python-guide.org/en/
 
 	pipenv install --dev
 
-This tool makes use of the [django-data-ingest](https://github.com/18F/django-data-ingest) tool, if you also are developing that tool at the same time, you will need to have a local copy of it.  You can then install and point to the local copy so the changes you make there will reflect on this tool immediately.
+This tool makes use of the [ReVAL](https://github.com/18F/ReVAL) tool, if you also are developing that tool at the same time, you will need to have a local copy of it.  You can then install and point to the local copy so the changes you make there will reflect on this tool immediately.
 
-	pipenv install -d -e <path to django-data-ingest>
+	pipenv install -d -e <path to ReVAL>
 
 You can then activate the Python virtual environment:
 

--- a/usda_fns_ingestor/requirements.txt
+++ b/usda_fns_ingestor/requirements.txt
@@ -1,10 +1,10 @@
 -i https://pypi.python.org/simple
--e git+https://github.com/18F/django-data-ingest.git@3086d3f514799fe30a1d507b7a6be90009c59411#egg=django-data-ingest
+-e git+https://github.com/18F/ReVAL.git@fa1d3d317e57799cef84a6c546a3a1f8f44e9c7e#egg=data-ingest
 attrs==19.1.0
 cchardet==2.1.4
 certifi==2019.3.9
 chardet==3.0.4
-click-default-group==1.2
+click-default-group==1.2.1
 click==7.0
 datapackage==1.6.2
 dj-database-url==0.5.0
@@ -23,7 +23,7 @@ jsonpointer==2.0
 jsonschema==3.0.1
 linear-tsv==1.1.0
 openpyxl==2.4.11
-psycopg2-binary==2.8.2
+psycopg2-binary==2.8.3
 pyrsistent==0.15.2
 python-dateutil==2.8.0
 pytz==2019.1


### PR DESCRIPTION
## Changes
- Changed django-data-ingest reference to ReVAL
- Pin down to the latest version of ReVAL v0.4.0.  This is to prevent new development that can potentially change any interfaces this validation service is using when we pause development in ReVAL.