### PR TITLE
Add missing staging manifest file

### DIFF
--- a/usda_fns_ingestor/manifests/manifest_staging.yml
+++ b/usda_fns_ingestor/manifests/manifest_staging.yml
@@ -1,0 +1,11 @@
+---
+applications:
+- name: usda-fns-ingestor
+  stack: cflinuxfs3
+  buildpack: python_buildpack
+  memory: 512mb
+  routes:
+    - route: usda-fns-dvs-staging.app.cloud.gov
+  instances: 2
+  services:
+   - usda-fns-ingestor-db


### PR DESCRIPTION
There was a missing staging manifest file, therefore deploying from master branch to staging environment failed.