### PR TITLE
Bind app variables

### DIFF
--- a/usda_fns_ingestor/manifests/manifest_dev_perm.yml
+++ b/usda_fns_ingestor/manifests/manifest_dev_perm.yml
@@ -9,5 +9,6 @@ applications:
   instances: 1
   services:
    - usda-fns-ingestor-db
+   - DJANGO
   env:
     DJANGO_SETTINGS_MODULE: usda_fns_ingestor.settings.cloud

--- a/usda_fns_ingestor/manifests/manifest_dev_temp.yml
+++ b/usda_fns_ingestor/manifests/manifest_dev_temp.yml
@@ -9,5 +9,6 @@ applications:
   instances: 1
   services:
    - usda-fns-ingestor-db
+   - DJANGO
   env:
     DJANGO_SETTINGS_MODULE: usda_fns_ingestor.settings.cloud

--- a/usda_fns_ingestor/manifests/manifest_prod_perm.yml
+++ b/usda_fns_ingestor/manifests/manifest_prod_perm.yml
@@ -9,5 +9,6 @@ applications:
   instances: 2
   services:
    - usda-fns-ingestor-db
+   - DJANGO
   env:
     DJANGO_SETTINGS_MODULE: usda_fns_ingestor.settings.cloud

--- a/usda_fns_ingestor/manifests/manifest_prod_temp.yml
+++ b/usda_fns_ingestor/manifests/manifest_prod_temp.yml
@@ -9,5 +9,6 @@ applications:
   instances: 2
   services:
    - usda-fns-ingestor-db
+   - DJANGO
   env:
     DJANGO_SETTINGS_MODULE: usda_fns_ingestor.settings.cloud

--- a/usda_fns_ingestor/manifests/manifest_staging_perm.yml
+++ b/usda_fns_ingestor/manifests/manifest_staging_perm.yml
@@ -9,5 +9,6 @@ applications:
   instances: 1
   services:
    - usda-fns-ingestor-db
+   - DJANGO
   env:
     DJANGO_SETTINGS_MODULE: usda_fns_ingestor.settings.cloud

--- a/usda_fns_ingestor/manifests/manifest_staging_temp.yml
+++ b/usda_fns_ingestor/manifests/manifest_staging_temp.yml
@@ -9,5 +9,6 @@ applications:
   instances: 1
   services:
    - usda-fns-ingestor-db
+   - DJANGO
   env:
     DJANGO_SETTINGS_MODULE: usda_fns_ingestor.settings.cloud

--- a/usda_fns_ingestor/manifests/manifest_test_perm.yml
+++ b/usda_fns_ingestor/manifests/manifest_test_perm.yml
@@ -1,0 +1,14 @@
+---
+applications:
+- name: usda-fns-ingestor-test
+  stack: cflinuxfs3
+  buildpack: python_buildpack
+  memory: 512mb
+  routes:
+    - route: usda-dvs-test.app.cloud.gov
+  instances: 1
+  services:
+   - usda-fns-ingestor-db-test
+   - DJANGO_TEST
+  env:
+    DJANGO_SETTINGS_MODULE: usda_fns_ingestor.settings

--- a/usda_fns_ingestor/manifests/manifest_test_perm.yml
+++ b/usda_fns_ingestor/manifests/manifest_test_perm.yml
@@ -1,3 +1,4 @@
+# This is to be used with ReVAL v0.3.0 in the testing environment
 ---
 applications:
 - name: usda-fns-ingestor-test


### PR DESCRIPTION
This is to bind the user-provided services for Django App variables to apps on cloud.gov.  If they were not bind, every time user-provided services will unbind.